### PR TITLE
fix: use title case to avoid robocop lint rules

### DIFF
--- a/Cumulocity/Cumulocity.py
+++ b/Cumulocity/Cumulocity.py
@@ -1069,7 +1069,7 @@ class Cumulocity:
         except AssertionError as ex:
             fail(f"not enough measurements were found. args={ex.args}")
 
-    @keyword("Delete Managed Object and Device User")
+    @keyword("Delete Managed Object And Device User")
     def delete_managed_object(
         self, external_id: str, external_id_type: str = "c8y_Serial", **kwargs
     ):


### PR DESCRIPTION
All keywords should use title case as this is RobotFramework convention and is enforced by default by [robocop](https://robocop.readthedocs.io/en/stable/index.html)