### PR TITLE
chore: update c8y-test-core library to 0.25.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,5 +24,5 @@ dependencies = [
   "robotframework >= 6.0.0, < 8.0.0",
   "python-dotenv >= 1.0.0, < 1.1.0",
   "dotmap >= 1.3.30, < 1.4.0",
-  "c8y-test-core @ git+https://github.com/reubenmiller/c8y-test-core.git@0.24.1#egg=c8y-test-core",
+  "c8y-test-core @ git+https://github.com/reubenmiller/c8y-test-core.git@0.25.1#egg=c8y-test-core",
 ]


### PR DESCRIPTION
Update c8y-test-core library to 0.25.1 to fix a bug where the password generated when registering a device would sometimes not pass the default Cumulocity password policy resulting in the device registration failing.