### PR TITLE
fix(registration): avoid using passwords with quotes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,5 +24,5 @@ dependencies = [
   "robotframework >= 6.0.0, < 8.0.0",
   "python-dotenv >= 1.0.0, < 1.1.0",
   "dotmap >= 1.3.30, < 1.4.0",
-  "c8y-test-core @ git+https://github.com/reubenmiller/c8y-test-core.git@0.29.2#egg=c8y-test-core",
+  "c8y-test-core @ git+https://github.com/reubenmiller/c8y-test-core.git@0.29.3#egg=c8y-test-core",
 ]


### PR DESCRIPTION
Having quotes in the password can cause incompatibilities when used in a shell if the user does not escape the single quotes. It is easier just to avoid the characters all together