### PR TITLE
chore: update c8y dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,5 +24,5 @@ dependencies = [
   "robotframework >= 6.0.0, < 8.0.0",
   "python-dotenv >= 1.0.0, < 1.1.0",
   "dotmap >= 1.3.30, < 1.4.0",
-  "c8y-test-core @ git+https://github.com/reubenmiller/c8y-test-core.git@0.30.0#egg=c8y-test-core",
+  "c8y-test-core @ git+https://github.com/reubenmiller/c8y-test-core.git@0.30.1#egg=c8y-test-core",
 ]


### PR DESCRIPTION
Update c8y dependency to add a fix for updating the Cumulocity CA credentials for an already registered device